### PR TITLE
Add initial structure for repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
-# dds_workshop
-Documentation for the DDS Workshop (Autumn 2024) 
+# DDS Unit User's Workshop 
+
+This repository contains the instructions for the hands-on sessions during the workshop 
+with SciLifeLab Unit Users (Autumn 2024).
+
+The documentation for different sessions can be found in the `docs` directory. 

--- a/docs/project_life_cycle_support_session.md
+++ b/docs/project_life_cycle_support_session.md
@@ -1,0 +1,1 @@
+# Project life cycle and support session

--- a/docs/registration_project_access_session.md
+++ b/docs/registration_project_access_session.md
@@ -1,0 +1,1 @@
+# Registration, client installation & project access session


### PR DESCRIPTION
We have opted to go with simple markdown files, rather than a GitHub pages site as we mostly just need code snippets, images and simple formatting. 

Doing it in GitHub rather than in a document means that attendees can get rolling updates. 